### PR TITLE
Add feature pages with placeholder components

### DIFF
--- a/src/app/game/page.js
+++ b/src/app/game/page.js
@@ -1,0 +1,5 @@
+import GameFeature from '@/components/game/GameFeature'
+
+export default function GamePage() {
+  return <GameFeature />
+}

--- a/src/app/players/page.js
+++ b/src/app/players/page.js
@@ -1,0 +1,5 @@
+import PlayersFeature from '@/components/players/PlayersFeature'
+
+export default function PlayersPage() {
+  return <PlayersFeature />
+}

--- a/src/app/tournaments/[id]/page.js
+++ b/src/app/tournaments/[id]/page.js
@@ -1,0 +1,6 @@
+import TournamentDetail from '@/components/tournaments/TournamentDetail'
+
+export default function TournamentPage({ params }) {
+  const { id } = params
+  return <TournamentDetail id={id} />
+}

--- a/src/app/tournaments/page.js
+++ b/src/app/tournaments/page.js
@@ -1,0 +1,5 @@
+import TournamentsFeature from '@/components/tournaments/TournamentsFeature'
+
+export default function TournamentsPage() {
+  return <TournamentsFeature />
+}

--- a/src/components/game/GameFeature.js
+++ b/src/components/game/GameFeature.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function GameFeature() {
+  return <div className="p-4">Game feature placeholder</div>
+}

--- a/src/components/players/PlayersFeature.js
+++ b/src/components/players/PlayersFeature.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function PlayersFeature() {
+  return <div className="p-4">Players feature placeholder</div>
+}

--- a/src/components/tournaments/TournamentDetail.js
+++ b/src/components/tournaments/TournamentDetail.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function TournamentDetail({ id }) {
+  return <div className="p-4">Tournament detail for id: {id}</div>
+}

--- a/src/components/tournaments/TournamentsFeature.js
+++ b/src/components/tournaments/TournamentsFeature.js
@@ -1,0 +1,14 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function TournamentsFeature() {
+  return (
+    <div className="p-4 space-y-2">
+      <div>Tournaments feature placeholder</div>
+      <Link href="/tournaments/1" className="text-blue-500 underline">
+        View sample tournament
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new feature pages for game, players, and tournaments
- render tournament details for a dynamic route
- create placeholder components for each feature

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c9e74bdc832e85280a1f8566187d