### PR TITLE
Add Prettier configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Darts is a simple example project built with [Next.js](https://nextjs.org). It c
    ```bash
    npm run dev
    ```
-3. Open <http://localhost:3000> in your browser.
+3. (Optional) Format the codebase:
+   ```bash
+   npm run format
+   ```
+4. Open <http://localhost:3000> in your browser.
 
 No additional environment variables are required for local development.
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
+        "prettier": "^3.5.3",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -5034,6 +5035,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -23,6 +24,7 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "prettier": "^3.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- add Prettier dev dependency
- configure `.prettierrc`
- add `format` script in `package.json`
- document formatting command in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843cf0548bc832eb6d6556f22d16764