### PR TITLE
Extend Zustand stores

### DIFF
--- a/src/stores/gameStore.js
+++ b/src/stores/gameStore.js
@@ -4,23 +4,59 @@ const defaultState = {
   gameMode: '501',
   gameState: 'not_started',
   currentPlayer: null,
+  dartCount: 0,
+  selectedPlayers: [],
   history: [],
   scores: {},
 }
 
+const startingScore = (mode) => {
+  const n = parseInt(mode, 10)
+  return Number.isNaN(n) ? 0 : n
+}
+
+const initScores = (players, mode) =>
+  players.reduce((acc, id) => ({ ...acc, [id]: startingScore(mode) }), {})
+
 const useGameStore = create((set, get) => ({
   ...defaultState,
   setGameMode: (mode) => set({ gameMode: mode }),
-  resetGame: () => set(defaultState),
+  resetGame: () =>
+    set((state) => ({
+      ...defaultState,
+      selectedPlayers: state.selectedPlayers,
+      scores: initScores(state.selectedPlayers, state.gameMode),
+    })),
+  setSelectedPlayers: (players) =>
+    set((state) => ({
+      selectedPlayers: players,
+      scores: initScores(players, state.gameMode),
+      currentPlayer: players[0] || null,
+    })),
+  startGame: () =>
+    set((state) => ({
+      gameState: 'in_progress',
+      dartCount: 0,
+      history: [],
+      scores: initScores(state.selectedPlayers, state.gameMode),
+      currentPlayer: state.selectedPlayers[0] || null,
+    })),
   handleDartThrow: (playerId, score) => {
     set((state) => {
-      const newScore = (state.scores[playerId] || 0) + score
+      const newScore =
+        (state.scores[playerId] || startingScore(state.gameMode)) - score
       const scores = { ...state.scores, [playerId]: newScore }
       const history = [...state.history, { playerId, score }]
+      const dartCount = state.dartCount + 1
       return {
         scores,
         history,
-        currentPlayer: playerId,
+        dartCount,
+        currentPlayer:
+          state.selectedPlayers[
+            (state.selectedPlayers.indexOf(playerId) + 1) %
+              state.selectedPlayers.length
+          ] || null,
         gameState: 'in_progress',
       }
     })
@@ -32,9 +68,15 @@ const useGameStore = create((set, get) => ({
       const history = state.history.slice(0, -1)
       const scores = {
         ...state.scores,
-        [last.playerId]: (state.scores[last.playerId] || 0) - last.score,
+        [last.playerId]: (state.scores[last.playerId] || 0) + last.score,
       }
-      return { history, scores, currentPlayer: last.playerId }
+      const dartCount = Math.max(0, state.dartCount - 1)
+      return {
+        history,
+        scores,
+        dartCount,
+        currentPlayer: last.playerId,
+      }
     })
   },
 }))

--- a/src/stores/playerStore.js
+++ b/src/stores/playerStore.js
@@ -1,13 +1,21 @@
 import { create } from 'zustand'
 
-const usePlayerStore = create((set) => ({
+const defaultState = {
   players: [],
   selectedForGame: [],
+}
+
+const usePlayerStore = create((set) => ({
+  ...defaultState,
   addPlayer: (player) =>
-    set((state) => ({ players: [...state.players, { id: Date.now(), ...player }] })),
+    set((state) => ({
+      players: [...state.players, { id: Date.now(), ...player }],
+    })),
   updatePlayer: (player) =>
     set((state) => ({
-      players: state.players.map((p) => (p.id === player.id ? { ...p, ...player } : p)),
+      players: state.players.map((p) =>
+        p.id === player.id ? { ...p, ...player } : p,
+      ),
     })),
   deletePlayer: (id) =>
     set((state) => ({
@@ -20,6 +28,8 @@ const usePlayerStore = create((set) => ({
         ? state.selectedForGame.filter((pid) => pid !== id)
         : [...state.selectedForGame, id],
     })),
+  clearSelection: () => set({ selectedForGame: [] }),
+  reset: () => set(defaultState),
 }))
 
 export default usePlayerStore

--- a/src/stores/tournamentStore.js
+++ b/src/stores/tournamentStore.js
@@ -1,11 +1,18 @@
 import { create } from 'zustand'
 
-const useTournamentStore = create((set, get) => ({
+const defaultState = {
   tournaments: [],
   currentTournamentId: null,
+}
+
+const useTournamentStore = create((set, get) => ({
+  ...defaultState,
   createTournament: (tournament) =>
     set((state) => ({
-      tournaments: [...state.tournaments, { id: Date.now(), matches: [], ...tournament }],
+      tournaments: [
+        ...state.tournaments,
+        { id: Date.now(), matches: [], ...tournament },
+      ],
     })),
   setActiveTournament: (id) => set({ currentTournamentId: id }),
   advanceWinner: (matchId, winner) => {
@@ -14,13 +21,29 @@ const useTournamentStore = create((set, get) => ({
     if (idx === -1) return
     const tournament = tournaments[idx]
     const matches = tournament.matches.map((m) =>
-      m.id === matchId ? { ...m, winner } : m
+      m.id === matchId ? { ...m, winner } : m,
     )
     const updated = { ...tournament, matches }
     set((state) => ({
-      tournaments: state.tournaments.map((t) => (t.id === currentTournamentId ? updated : t)),
+      tournaments: state.tournaments.map((t) =>
+        t.id === currentTournamentId ? updated : t,
+      ),
     }))
   },
+  addMatchToTournament: (match) => {
+    const { currentTournamentId, tournaments } = get()
+    const idx = tournaments.findIndex((t) => t.id === currentTournamentId)
+    if (idx === -1) return
+    const tournament = tournaments[idx]
+    const matches = [...tournament.matches, { id: Date.now(), ...match }]
+    const updated = { ...tournament, matches }
+    set((state) => ({
+      tournaments: state.tournaments.map((t) =>
+        t.id === currentTournamentId ? updated : t,
+      ),
+    }))
+  },
+  reset: () => set(defaultState),
 }))
 
 export default useTournamentStore


### PR DESCRIPTION
## Summary
- add dart count and selected player state to the game store
- provide start/reset helpers and handle scoring logic
- expose clear/reset helpers in player and tournament stores

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684437dced80832e9cac28c3038777ee