### PR TITLE
Add constants and utility modules

### DIFF
--- a/src/lib/constants/dartboardConstants.js
+++ b/src/lib/constants/dartboardConstants.js
@@ -1,0 +1,12 @@
+export const ringRadii = {
+  double: 170,
+  outerSingle: 162,
+  triple: 107,
+  innerSingle: 99,
+  outerBull: 15.9,
+  bull: 6.35,
+}
+
+export const numberOrder = [
+  20, 1, 18, 4, 13, 6, 10, 15, 2, 17, 3, 19, 7, 16, 8, 11, 14, 9, 12, 5,
+]

--- a/src/lib/constants/gameConstants.js
+++ b/src/lib/constants/gameConstants.js
@@ -1,0 +1,3 @@
+export const cricketNumbers = [20, 19, 18, 17, 16, 15, 25]
+
+export const gameModes = ['301', '501', '701']

--- a/src/lib/utils/chartUtils.js
+++ b/src/lib/utils/chartUtils.js
@@ -1,0 +1,11 @@
+export const buildBarSeries = (labels, values) =>
+  labels.map((label, idx) => ({ label, value: values[idx] || 0 }))
+
+export const cumulativeTotals = (values) => {
+  const totals = []
+  values.reduce((acc, val, idx) => {
+    totals[idx] = acc + val
+    return totals[idx]
+  }, 0)
+  return totals
+}

--- a/src/lib/utils/formatters.js
+++ b/src/lib/utils/formatters.js
@@ -1,0 +1,5 @@
+export const formatScore = (score) =>
+  score === null || score === undefined ? '-' : `${score}`
+
+export const formatPercentage = (value, digits = 0) =>
+  `${(value * 100).toFixed(digits)}%`


### PR DESCRIPTION
## Summary
- define dartboard radii and number ordering
- add cricket numbers and available game modes
- provide basic score formatter and chart helpers

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684439790468832e8612d4b1fd371fc5