### PR TITLE
Add reference note for original dartboard implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Darts is a simple example project built with [Next.js](https://nextjs.org). It c
 No additional environment variables are required for local development.
 
 The application is deployed on Vercel: <https://darts.vercel.app>
+
+## Reference
+
+This project contains the original dartboard implementation at
+`docs/mvp_code_reference.txt` for reference during refactoring. Contributors
+should consult this file if they need clarity on the initial logic.


### PR DESCRIPTION
## Summary
- add documentation note for the original MVP dartboard code reference

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497c5f6ed4832ea35be5ca84e21f0f