### PR TITLE
Implement players and tournaments features

### DIFF
--- a/src/components/players/PlayersFeature.js
+++ b/src/components/players/PlayersFeature.js
@@ -1,5 +1,69 @@
 'use client'
 
+import { useState } from 'react'
+import usePlayerStore from '@/stores/playerStore'
+
 export default function PlayersFeature() {
-  return <div className="p-4">Players feature placeholder</div>
+  const {
+    players,
+    addPlayer,
+    deletePlayer,
+    selectPlayerForGame,
+    selectedForGame,
+    clearSelection,
+  } = usePlayerStore((state) => state)
+
+  const [name, setName] = useState('')
+
+  const handleAdd = () => {
+    if (!name.trim()) return
+    addPlayer({ name: name.trim() })
+    setName('')
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="space-x-2">
+        <input
+          type="text"
+          className="border px-2 py-1"
+          placeholder="Player name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          className="px-2 py-1 bg-blue-500 text-white"
+          onClick={handleAdd}
+        >
+          Add
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {players.map((p) => (
+          <li key={p.id} className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={selectedForGame.includes(p.id)}
+              onChange={() => selectPlayerForGame(p.id)}
+            />
+            <span className="flex-1">{p.name}</span>
+            <button
+              className="px-2 py-1 bg-red-500 text-white"
+              onClick={() => deletePlayer(p.id)}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      {selectedForGame.length > 0 && (
+        <button
+          className="px-2 py-1 bg-gray-500 text-white"
+          onClick={clearSelection}
+        >
+          Clear Selection
+        </button>
+      )}
+    </div>
+  )
 }

--- a/src/components/tournaments/TournamentsFeature.js
+++ b/src/components/tournaments/TournamentsFeature.js
@@ -1,14 +1,54 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
+import useTournamentStore from '@/stores/tournamentStore'
+import usePlayerStore from '@/stores/playerStore'
 
 export default function TournamentsFeature() {
+  const { tournaments, createTournament } = useTournamentStore((state) => state)
+  const players = usePlayerStore((state) => state.players)
+  const [name, setName] = useState('')
+
+  const handleCreate = () => {
+    if (!name.trim()) return
+    createTournament({
+      name: name.trim(),
+      participants: players.map((p) => p.id),
+    })
+    setName('')
+  }
+
   return (
-    <div className="p-4 space-y-2">
-      <div>Tournaments feature placeholder</div>
-      <Link href="/tournaments/1" className="text-blue-500 underline">
-        View sample tournament
-      </Link>
+    <div className="p-4 space-y-4">
+      <div className="space-x-2">
+        <input
+          type="text"
+          className="border px-2 py-1"
+          placeholder="Tournament name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          className="px-2 py-1 bg-blue-500 text-white"
+          onClick={handleCreate}
+        >
+          Create
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {tournaments.map((t) => (
+          <li key={t.id} className="flex items-center space-x-2">
+            <span className="flex-1">{t.name}</span>
+            <Link
+              href={`/tournaments/${t.id}`}
+              className="text-blue-500 underline"
+            >
+              View
+            </Link>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add player management UI with add/delete/select capabilities
- add tournament list and creation form
- hook up both features to zustand stores

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68497d122404832e9719c8456452d7ad