### PR TITLE
Add Next.js config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ No additional environment variables are required for local development.
 
 The application is deployed on Vercel: <https://darts.vercel.app>
 
+## Next.js Configuration
+
+This project uses the `/app` directory. To enable it and other runtime checks,
+`src/next.config.ts` sets `experimental.appDir` and `reactStrictMode` to `true`.
+Remote images are also allowed from `example.com` via the `images.domains`
+setting.
+
 ## Reference
 
 This project contains the original dartboard implementation at

--- a/src/next.config.ts
+++ b/src/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  experimental: {
+    appDir: true,
+  },
+  images: {
+    domains: ["example.com"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure `experimental.appDir`, `reactStrictMode` and allowed image domains
- document Next.js settings in the README

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a7211844832eb252d9ba9c2046d5