### PR TITLE
Fix ScoreboardUI prop usage

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -23,6 +23,7 @@ const ScoreboardUI = ({
   gameHistory,
   checkoutSuggestion,
   bogeyWarning,
+  selectedPlayers,
 }) => (
         <>
           <div className="cricket-scoreboard">

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1,8 +1,8 @@
 'use client'
 import React, { useState, useEffect, Fragment } from 'react'
-import PlayerManagement from './PlayerManagement';
-import ScoreboardUI from './ScoreboardUI';
-import DartboardSVG from './DartboardSVG';
+import PlayerManagement from './PlayerManagement'
+import ScoreboardUI from './ScoreboardUI'
+import DartboardSVG from './DartboardSVG'
 
 // Main component for the Stunning Dartboard application
 const StunningDartboard = () => {
@@ -2106,6 +2106,7 @@ const StunningDartboard = () => {
           gameHistory={gameHistory}
           checkoutSuggestion={checkoutSuggestion}
           bogeyWarning={bogeyWarning}
+          selectedPlayers={selectedPlayers}
         />
       )}
       <DartboardSVG


### PR DESCRIPTION
## Summary
- add missing `selectedPlayers` prop in `ScoreboardUI`
- pass `selectedPlayers` when rendering `<ScoreboardUI>`

## Testing
- `npm test` *(fails: SyntaxError in ScoreboardUI.js)*

------
https://chatgpt.com/codex/tasks/task_e_6849c89fddc0832e80750bf4136e21c4