### PR TITLE
Add client directives to scoreboard components

### DIFF
--- a/src/components/dartboard/PlayerManagement.js
+++ b/src/components/dartboard/PlayerManagement.js
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 
 const PlayerManagement = ({

--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -1,3 +1,4 @@
+'use client'
 import React, { Fragment } from 'react'
 
 const ScoreboardUI = ({


### PR DESCRIPTION
## Summary
- mark ScoreboardUI and PlayerManagement as client components

## Testing
- `npm test` *(fails: Expected '}', got 'export')*

------
https://chatgpt.com/codex/tasks/task_e_6849ce826e2c832eb2a3df1692e6d902