### PR TITLE
Implement basic logging utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ No additional environment variables are required for local development.
 
 The application is deployed on Vercel: <https://darts.vercel.app>
 
+## Logging
+
+Use the `logger` utility for any runtime messages instead of calling
+`console.log` directly. Import it from `src/lib/logger`:
+
+```javascript
+import logger from '@/lib/logger'
+
+logger.info('Application started')
+```
+
+Debug output is suppressed when `NODE_ENV` is set to `production` so logs stay
+quiet in deployments. See `docs/server_logging.md` for backend logging tips.
+
 ## Next.js Configuration
 
 This project uses the `/app` directory. To enable it and other runtime checks,

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,24 @@
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 }
+const prodLevel = 'warn'
+const devLevel = 'debug'
+const currentLevel =
+  process.env.NODE_ENV === 'production' ? prodLevel : devLevel
+
+const shouldLog = (level) => LEVELS[level] >= LEVELS[currentLevel]
+
+export const logger = {
+  debug: (...args) => {
+    if (shouldLog('debug')) console.debug(...args)
+  },
+  info: (...args) => {
+    if (shouldLog('info')) console.info(...args)
+  },
+  warn: (...args) => {
+    if (shouldLog('warn')) console.warn(...args)
+  },
+  error: (...args) => {
+    if (shouldLog('error')) console.error(...args)
+  },
+}
+
+export default logger


### PR DESCRIPTION
## Summary
- add a simple logger at `src/lib/logger.js`
- document how to use the client logger in the README
- document server logging practices in `docs/server_logging.md` (already included)

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d07c4090832e9dd34674a1a8026d