### PR TITLE
Fix closing brace in ScoreboardUI

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -470,6 +470,6 @@ const ScoreboardUI = ({
                 </div>
               </div>
             </div>
-)
+)}
 
 export default ScoreboardUI


### PR DESCRIPTION
## Summary
- fix ending brace in `ScoreboardUI.js`

## Testing
- `npm run format` *(fails: SyntaxError in ScoreboardUI.js)*

------
https://chatgpt.com/codex/tasks/task_e_684b3c349ad4832e910dcf09178cece2