### PR TITLE
Fix missing closing fragment in ScoreboardUI

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -378,10 +378,10 @@ const ScoreboardUI = ({
                       </div>
                     </>
                   )}
-                </div>
               </div>
             </div>
-          )}
+          </div>
+      )}
 
           {['bobs_27', 'around_the_clock', 'shanghai'].includes(gameMode) && (
             <div className="generic-scoreboard">
@@ -470,6 +470,9 @@ const ScoreboardUI = ({
                 </div>
               </div>
             </div>
-)}
+          )}
+        </>
+      )
+
 
 export default ScoreboardUI


### PR DESCRIPTION
## Summary
- close fragment and parentheses in `ScoreboardUI.js`

## Testing
- `npm run lint`
- `npm test` *(fails: GameSelectionIcon is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684b3d582fdc832eb24c090e1b8d101a