### PR TITLE
Extract GameSelectionIcon component

### DIFF
--- a/src/components/dartboard/GameSelectionIcon.js
+++ b/src/components/dartboard/GameSelectionIcon.js
@@ -1,0 +1,65 @@
+import React from 'react'
+
+const GameSelectionIcon = ({ type }) => {
+  const icons = {
+    standard: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+      </svg>
+    ),
+    party: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+        <line x1="10" y1="9" x2="8" y2="9" />
+      </svg>
+    ),
+    practice: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+      </svg>
+    ),
+  }
+  return (
+    <div className="flex items-center gap-3 text-white font-bold">
+      {icons[type]}
+      <span className="text-lg">
+        {type.charAt(0).toUpperCase() + type.slice(1)} Games
+      </span>
+    </div>
+  )
+}
+
+export default GameSelectionIcon

--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -1,5 +1,6 @@
 'use client'
 import React, { Fragment } from 'react'
+import GameSelectionIcon from './GameSelectionIcon'
 
 const ScoreboardUI = ({
   activeGameSection,

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1629,67 +1629,6 @@ const StunningDartboard = () => {
     setActiveGameSection((prev) => (prev === section ? null : section))
   }
 
-  const GameSelectionIcon = ({ type }) => {
-    const icons = {
-      standard: (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-        </svg>
-      ),
-      party: (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-          <polyline points="14 2 14 8 20 8" />
-          <line x1="16" y1="13" x2="8" y2="13" />
-          <line x1="16" y1="17" x2="8" y2="17" />
-          <line x1="10" y1="9" x2="8" y2="9" />
-        </svg>
-      ),
-      practice: (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-        </svg>
-      ),
-    }
-    return (
-      <div className="flex items-center gap-3 text-white font-bold">
-        {icons[type]}
-        <span className="text-lg">
-          {type.charAt(0).toUpperCase() + type.slice(1)} Games
-        </span>
-      </div>
-    )
-  }
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4 relative bg-gray-900">


### PR DESCRIPTION
## Summary
- add `GameSelectionIcon` component under dartboard components
- import and use `GameSelectionIcon` in `ScoreboardUI`
- remove inline icon code from `StunningDartboard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6c7844d4832e847f4e46ad4e0be7