### PR TITLE
Simplify Next.js placeholders

### DIFF
--- a/src/app/game/page.js
+++ b/src/app/game/page.js
@@ -1,5 +1,5 @@
-import GameFeature from '@/components/game/GameFeature'
+// import GameFeature from '@/components/game/GameFeature'
 
 export default function GamePage() {
-  return <GameFeature />
+  return <div className="p-4">Game coming soon...</div>
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,29 +1,29 @@
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
-import Header from "@/components/ui/Header";
+// import { Geist, Geist_Mono } from "next/font/google";
+// import "./globals.css";
+import Header from '@/components/ui/Header'
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
+// const geistSans = Geist({
+//   variable: "--font-geist-sans",
+//   subsets: ["latin"],
+// });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+// const geistMono = Geist_Mono({
+//   variable: "--font-geist-mono",
+//   subsets: ["latin"],
+// });
 
 export const metadata = {
-  title: "Stunning Dartboard",
-  description: "Scorekeeping for all your darts games",
-};
+  title: 'Stunning Dartboard',
+  description: 'Scorekeeping for all your darts games',
+}
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body>
         <Header />
         {children}
       </body>
     </html>
-  );
+  )
 }

--- a/src/app/players/page.js
+++ b/src/app/players/page.js
@@ -1,5 +1,5 @@
-import PlayersFeature from '@/components/players/PlayersFeature'
+// import PlayersFeature from '@/components/players/PlayersFeature'
 
 export default function PlayersPage() {
-  return <PlayersFeature />
+  return <div className="p-4">Players page placeholder</div>
 }

--- a/src/app/tournaments/[id]/page.js
+++ b/src/app/tournaments/[id]/page.js
@@ -1,6 +1,6 @@
-import TournamentDetail from '@/components/tournaments/TournamentDetail'
+// import TournamentDetail from '@/components/tournaments/TournamentDetail'
 
 export default function TournamentPage({ params }) {
   const { id } = params
-  return <TournamentDetail id={id} />
+  return <div className="p-4">Tournament {id}</div>
 }

--- a/src/app/tournaments/page.js
+++ b/src/app/tournaments/page.js
@@ -1,5 +1,5 @@
-import TournamentsFeature from '@/components/tournaments/TournamentsFeature'
+// import TournamentsFeature from '@/components/tournaments/TournamentsFeature'
 
 export default function TournamentsPage() {
-  return <TournamentsFeature />
+  return <div className="p-4">Tournaments page placeholder</div>
 }


### PR DESCRIPTION
## Summary
- remove font imports and Tailwind CSS from layout
- show placeholders for games, players and tournaments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c75e2b304832eb0a0f402e8bc7fee