### PR TITLE
Fix layout imports and render features

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,16 +1,16 @@
-// import { Geist, Geist_Mono } from "next/font/google";
-// import "./globals.css";
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
 import Header from '@/components/ui/Header'
 
-// const geistSans = Geist({
-//   variable: "--font-geist-sans",
-//   subsets: ["latin"],
-// });
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+})
 
-// const geistMono = Geist_Mono({
-//   variable: "--font-geist-mono",
-//   subsets: ["latin"],
-// });
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+})
 
 export const metadata = {
   title: 'Stunning Dartboard',
@@ -19,7 +19,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}> 
       <body>
         <Header />
         {children}

--- a/src/app/players/page.js
+++ b/src/app/players/page.js
@@ -1,5 +1,5 @@
-// import PlayersFeature from '@/components/players/PlayersFeature'
+import PlayersFeature from '@/components/players/PlayersFeature'
 
 export default function PlayersPage() {
-  return <div className="p-4">Players page placeholder</div>
+  return <PlayersFeature />
 }

--- a/src/app/tournaments/page.js
+++ b/src/app/tournaments/page.js
@@ -1,5 +1,5 @@
-// import TournamentsFeature from '@/components/tournaments/TournamentsFeature'
+import TournamentsFeature from '@/components/tournaments/TournamentsFeature'
 
 export default function TournamentsPage() {
-  return <div className="p-4">Tournaments page placeholder</div>
+  return <TournamentsFeature />
 }


### PR DESCRIPTION
## Summary
- load `globals.css` and Google fonts in app layout
- apply font variables to the `<html>` tag
- render `PlayersFeature` and `TournamentsFeature` pages

## Testing
- `npm test` *(fails: Cannot update a component (`StunningDartboard`) while rendering a different component)*

------
https://chatgpt.com/codex/tasks/task_e_684c818c4178832ebeb67d41cb8f33b3