### PR TITLE
Conditionally render dartboard sections

### DIFF
--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -2003,24 +2003,26 @@ const StunningDartboard = () => {
           )}
         </div>
       )}
-      <PlayerManagement
-        newPlayerName={newPlayerName}
-        setNewPlayerName={setNewPlayerName}
-        addPlayer={addPlayer}
-        players={players}
-        selectedPlayers={selectedPlayers}
-        selectPlayer={selectPlayer}
-        botOpponent={botOpponent}
-        setBotOpponent={setBotOpponent}
-        editingPlayer={editingPlayer}
-        setEditingPlayer={setEditingPlayer}
-        deletePlayer={deletePlayer}
-        updatePlayerName={updatePlayerName}
-        generateBarChartData={generateBarChartData}
-        generateRadarData={generateRadarData}
-        generateRadarGridPath={generateRadarGridPath}
-        generateRadarAxes={generateRadarAxes}
-      />
+      {currentTab === 'players' && (
+        <PlayerManagement
+          newPlayerName={newPlayerName}
+          setNewPlayerName={setNewPlayerName}
+          addPlayer={addPlayer}
+          players={players}
+          selectedPlayers={selectedPlayers}
+          selectPlayer={selectPlayer}
+          botOpponent={botOpponent}
+          setBotOpponent={setBotOpponent}
+          editingPlayer={editingPlayer}
+          setEditingPlayer={setEditingPlayer}
+          deletePlayer={deletePlayer}
+          updatePlayerName={updatePlayerName}
+          generateBarChartData={generateBarChartData}
+          generateRadarData={generateRadarData}
+          generateRadarGridPath={generateRadarGridPath}
+          generateRadarAxes={generateRadarAxes}
+        />
+      )}
       {currentTab === 'game' && (
         <ScoreboardUI
           activeGameSection={activeGameSection}
@@ -2048,14 +2050,16 @@ const StunningDartboard = () => {
           selectedPlayers={selectedPlayers}
         />
       )}
-      <DartboardSVG
-        center={center}
-        radii={radii}
-        generateSegments={generateSegments}
-        generateNumbers={generateNumbers}
-        handleDartThrow={handleDartThrow}
-        BullseyeGlowWrapper={BullseyeGlowWrapper}
-      />
+      {currentTab === 'game' && (
+        <DartboardSVG
+          center={center}
+          radii={radii}
+          generateSegments={generateSegments}
+          generateNumbers={generateNumbers}
+          handleDartThrow={handleDartThrow}
+          BullseyeGlowWrapper={BullseyeGlowWrapper}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show Player Management only on Players tab
- show Scoreboard UI and board only on Game tab
- keep tournament and rules sections behind their tab conditions

## Testing
- `npm install`
- `npm test` *(fails: Cannot update a component while rendering a different component)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f0de04c832eaf08effe3077f63b