### PR TITLE
Fix wedge color order

### DIFF
--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1340,7 +1340,8 @@ const StunningDartboard = () => {
       const wedgeStartAngle = -99
       const currentAngle = wedgeStartAngle + i * angleIncrement
       const nextAngle = currentAngle + angleIncrement
-      const isBlackWedge = i % 2 !== 0
+      // Start color alternating with black/red on the first wedge (20)
+      const isBlackWedge = i % 2 === 0
       const primaryColorClass = isBlackWedge ? 'color-b' : 'color-a'
       const ringColorClass = isBlackWedge ? 'color-r' : 'color-g'
 


### PR DESCRIPTION
## Summary
- correct wedge color alternation so first wedge (20) uses black/red

## Testing
- `npm install`
- `CI=true npm test -- -i` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_684c9691ab68832e90d957aaf21812cb