### PR TITLE
Refactor winner logic

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -10,7 +10,7 @@ const ScoreboardUI = ({
   practiceModes,
   gameMode,
   setGameModeAndReset,
-  isGameWon,
+  winner,
   KillerScoreboard,
   gameState,
   currentPlayer,
@@ -135,15 +135,15 @@ const ScoreboardUI = ({
             </div>
           </div>
 
-          {isGameWon() && (
+          {winner && (
             <div className="winner-display">
               <div className="winner-text">
                 🏆{' '}
-                {isGameWon() === 'Draw'
+                {winner === 'Draw'
                   ? 'GAME DRAWN!'
-                  : isGameWon() === 'Practice Over'
+                  : winner === 'Practice Over'
                     ? 'PRACTICE COMPLETE'
-                    : `${gameState[isGameWon().toLowerCase().replace(' ', '')].name} WINS!`}{' '}
+                    : `${gameState[winner.toLowerCase().replace(' ', '')].name} WINS!`}{' '}
                 🏆
               </div>
             </div>
@@ -354,7 +354,7 @@ const ScoreboardUI = ({
                       <div className="target-display">
                         Darts Remaining: {gameState.player1.dartsRemaining}
                       </div>
-                      {isGameWon() === 'Practice Over' && (
+                      {winner === 'Practice Over' && (
                         <div className="practice-summary">
                           <div className="practice-summary-stat">
                             T20s Hit: {gameState.player1.t20s}

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import PlayerManagement from './PlayerManagement'
 import ScoreboardUI from './ScoreboardUI'
 import DartboardSVG from './DartboardSVG'
@@ -1186,6 +1186,11 @@ const StunningDartboard = () => {
     return winner
   }
 
+  const winner = useMemo(
+    () => isGameWon(),
+    [isGameWon, gameState, gameHistory, gameMode, selectedPlayers],
+  )
+
   const handleTournamentPlayerSelect = (playerId) => {
     setTournamentPlayerSelection((prev) =>
       prev.includes(playerId)
@@ -2033,7 +2038,7 @@ const StunningDartboard = () => {
           practiceModes={practiceModes}
           gameMode={gameMode}
           setGameModeAndReset={setGameModeAndReset}
-          isGameWon={isGameWon}
+          winner={winner}
           KillerScoreboard={KillerScoreboard}
           gameState={gameState}
           currentPlayer={currentPlayer}


### PR DESCRIPTION
## Summary
- compute the winner once in `StunningDartboard`
- pass `winner` down to `ScoreboardUI`
- render winner information using the prop instead of calling `isGameWon`

## Testing
- `npm run lint`
- `npm test` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_684c9c0a0dc4832e9eb3cce69a1c7fa3