### PR TITLE
Fix effect loop tests

### DIFF
--- a/src/components/dartboard/__tests__/StunningDartboard.test.js
+++ b/src/components/dartboard/__tests__/StunningDartboard.test.js
@@ -8,5 +8,6 @@ describe('StunningDartboard', () => {
       screen.getByRole('heading', { name: /precision dartboard/i })
     ).toBeInTheDocument();
     expect(document.querySelector('.dartboard-component')).toBeInTheDocument();
+    expect(document.querySelector('.winner-display')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- check that the winner display stays hidden on first render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca0824d8c832ebd1a2d1cde4e1a87