### PR TITLE
Enable dartboard toggle and scoreboard clicks

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -26,6 +26,9 @@ const ScoreboardUI = ({
   checkoutSuggestion,
   bogeyWarning,
   selectedPlayers,
+  showBoard,
+  toggleBoardVisibility,
+  handleCricketNumberClick,
 }) => (
         <>
           <div className="cricket-scoreboard">
@@ -176,6 +179,9 @@ const ScoreboardUI = ({
                   >
                     BACK TURN
                   </button>
+                  <button className="control-btn" onClick={toggleBoardVisibility}>
+                    {showBoard ? 'HIDE BOARD' : 'SHOW BOARD'}
+                  </button>
                 </div>
               </div>
               <div className="last-dart-display">
@@ -216,7 +222,10 @@ const ScoreboardUI = ({
                 </div>
                 {cricketNumbers.concat(['bull']).map((num) => (
                   <Fragment key={num}>
-                    <div className="cricket-number">
+                    <div
+                      className="cricket-number"
+                      onClick={() => handleCricketNumberClick(num)}
+                    >
                       {num === 'bull' ? 'BULL' : num}
                     </div>
                     <div

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -32,6 +32,8 @@ const StunningDartboard = () => {
   const [activeGameSection, setActiveGameSection] = useState('standard')
   const [highlightedSegments, setHighlightedSegments] = useState([])
   const [bogeyWarning, setBogeyWarning] = useState('')
+  const [showBoard, setShowBoard] = useState(true)
+  const toggleBoardVisibility = () => setShowBoard((prev) => !prev)
 
   // Player management state
   const [players, setPlayers] = useState([
@@ -1186,6 +1188,10 @@ const StunningDartboard = () => {
     return winner
   }
 
+  const handleCricketNumberClick = (number) => {
+    handleDartThrow(`single-${number}`)
+  }
+
   const winner = useMemo(
     () => isGameWon(),
     [isGameWon, gameState, gameHistory, gameMode, selectedPlayers],
@@ -2054,18 +2060,22 @@ const StunningDartboard = () => {
           checkoutSuggestion={checkoutSuggestion}
           bogeyWarning={bogeyWarning}
           selectedPlayers={selectedPlayers}
+          showBoard={showBoard}
+          toggleBoardVisibility={toggleBoardVisibility}
+          handleCricketNumberClick={handleCricketNumberClick}
         />
       )}
-      {currentTab === 'game' && (
-        <DartboardSVG
-          center={center}
-          radii={radii}
-          generateSegments={generateSegments}
-          generateNumbers={generateNumbers}
-          handleDartThrow={handleDartThrow}
-          BullseyeGlowWrapper={BullseyeGlowWrapper}
-        />
-      )}
+      {currentTab === 'game' &&
+        showBoard && (
+          <DartboardSVG
+            center={center}
+            radii={radii}
+            generateSegments={generateSegments}
+            generateNumbers={generateNumbers}
+            handleDartThrow={handleDartThrow}
+            BullseyeGlowWrapper={BullseyeGlowWrapper}
+          />
+        )}
     </div>
   )
 }

--- a/src/components/dartboard/__tests__/StunningDartboard.test.js
+++ b/src/components/dartboard/__tests__/StunningDartboard.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import StunningDartboard from '../StunningDartboard';
 
 describe('StunningDartboard', () => {
@@ -9,5 +9,26 @@ describe('StunningDartboard', () => {
     ).toBeInTheDocument();
     expect(document.querySelector('.dartboard-component')).toBeInTheDocument();
     expect(document.querySelector('.winner-display')).not.toBeInTheDocument();
+  });
+
+  it('toggles board visibility when button clicked', () => {
+    render(<StunningDartboard />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cricket' }));
+    const toggleBtn = screen.getByRole('button', { name: /hide board/i });
+    expect(document.querySelector('svg.dartboard-svg')).toBeInTheDocument();
+    fireEvent.click(toggleBtn);
+    expect(document.querySelector('svg.dartboard-svg')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show board/i })).toBeInTheDocument();
+  });
+
+  it('updates marks when number cell clicked', () => {
+    render(<StunningDartboard />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cricket' }));
+    const markCell = document.querySelectorAll('.marks-display')[0];
+    expect(markCell.textContent).toBe('');
+    const numberCell = document.querySelectorAll('.cricket-number')[1];
+    fireEvent.click(numberCell);
+    const updatedMark = document.querySelectorAll('.marks-display')[0];
+    expect(updatedMark.textContent).toBe('/');
   });
 });


### PR DESCRIPTION
## Summary
- add `showBoard` state and toggler in `StunningDartboard`
- expose board toggle and new click handler to `ScoreboardUI`
- show a Show/Hide Board button for Cricket
- allow clicking cricket numbers to score
- test board visibility toggle and clicking numbers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ca4affd58832e901d2bffdeba8b73