### PR TITLE
Separate dartboard from scoreboard

### DIFF
--- a/src/components/dartboard/ScoreboardUI.js
+++ b/src/components/dartboard/ScoreboardUI.js
@@ -161,18 +161,15 @@ const ScoreboardUI = ({
     {gameMode === 'killer' && <KillerScoreboard />}
 
     {gameMode === 'cricket' && (
-      <div className="cricket-scoreboard relative">
-        {showBoard && (
-          <div className="dartboard-overlay absolute inset-0">
-            {dartboardOverlay}
-          </div>
-        )}
-        <div className="cricket-header">
-          <h2 className="cricket-title">CRICKET SCOREBOARD</h2>
-          <div className="game-controls">
-            <button className="control-btn" onClick={resetGame}>
-              RESET
-            </button>
+      <>
+        {showBoard && <div className="dartboard-card">{dartboardOverlay}</div>}
+        <div className="cricket-scoreboard">
+          <div className="cricket-header">
+            <h2 className="cricket-title">CRICKET SCOREBOARD</h2>
+            <div className="game-controls">
+              <button className="control-btn" onClick={resetGame}>
+                RESET
+              </button>
             <button className="control-btn" onClick={() => nextPlayer()}>
               NEXT PLAYER
             </button>
@@ -251,8 +248,8 @@ const ScoreboardUI = ({
           ))}
         </div>
       </div>
+    </>
     )}
-
     {['301', '501', '701'].includes(gameMode) && (
       <div className="cricket-scoreboard">
         <div className="cricket-header">

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1779,6 +1779,20 @@ const StunningDartboard = () => {
 
         .cricket-scoreboard { /* removed scale transform to keep default size */ min-height: 36rem; }
 
+        .dartboard-card {
+          background: rgba(15,15,35,0.95);
+          backdrop-filter: blur(20px);
+          border: 1px solid rgba(99,102,241,0.3);
+          border-radius: 24px;
+          box-shadow: 0 20px 40px rgba(0,0,0,0.4), 0 0 0 1px rgba(99,102,241,0.1), inset 0 1px 0 rgba(255,255,255,0.1);
+          padding: 1.5rem;
+          margin-bottom: 2rem;
+          max-width: 800px;
+          width: 100%;
+          display: flex;
+          justify-content: center;
+        }
+
         .cricket-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; gap: 1rem; }
         .cricket-title, .comparison-title, .game-selection-title { font-family: 'Orbitron', monospace; font-weight: 700; font-size: clamp(18px, 4vw, 24px); background: linear-gradient(135deg, #06b6d4, #8b5cf6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
         .game-controls { display: flex; gap: 0.75rem; flex-wrap: wrap; }

--- a/src/components/dartboard/__tests__/StunningDartboard.test.js
+++ b/src/components/dartboard/__tests__/StunningDartboard.test.js
@@ -15,12 +15,10 @@ describe('StunningDartboard', () => {
     render(<StunningDartboard />)
     fireEvent.click(screen.getByRole('button', { name: 'Cricket' }))
     const toggleBtn = screen.getByRole('button', { name: /hide board/i })
-    const scoreboard = screen
-      .getByText(/cricket scoreboard/i)
-      .closest('.cricket-scoreboard')
-    expect(scoreboard.querySelector('svg.dartboard-svg')).toBeInTheDocument()
+    const boardCard = document.querySelector('.dartboard-card')
+    expect(boardCard.querySelector('svg.dartboard-svg')).toBeInTheDocument()
     fireEvent.click(toggleBtn)
-    expect(document.querySelector('svg.dartboard-svg')).not.toBeInTheDocument()
+    expect(document.querySelector('.dartboard-card')).not.toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /show board/i }),
     ).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- render dartboard in its own card rather than overlaying the cricket scoreboard
- style new `.dartboard-card` container
- update scoreboard tests for new board location

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd9928284832e8b2d53c82a731854