### PR TITLE
Add GameHUD component with HUD layout and tests

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,3 +26,56 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Game HUD styles */
+.game-hud {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.hud-top-bar,
+.hud-bottom {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 1rem;
+  background: rgba(15, 15, 35, 0.6);
+  backdrop-filter: blur(10px);
+}
+.hud-top-bar { top: 0; }
+.hud-bottom { bottom: 0; }
+.hud-board {
+  width: 65vw;
+  height: 65vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.hud-side {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 15%;
+  max-width: 200px;
+  padding: 1rem;
+  background: rgba(15, 15, 35, 0.6);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: width 0.3s ease, opacity 0.3s ease;
+}
+.hud-side.left { left: 0; }
+.hud-side.right { right: 0; }
+.hud-side.collapsed { width: 60px; opacity: 0.7; }
+.marks-row { display: flex; gap: 4px; margin-top: 4px; }
+.cricket-dot { width: 10px; height: 10px; border-radius: 50%; background: white; }
+.cricket-dot.hit-1 { background: #facc15; }
+.cricket-dot.hit-2,
+.cricket-dot.hit-3 { background: #22c55e; }

--- a/src/components/game/GameFeature.js
+++ b/src/components/game/GameFeature.js
@@ -1,11 +1,11 @@
 'use client'
 
-import StunningDartboard from '../dartboard/StunningDartboard'
+import GameHUD from '../hud/GameHUD'
 
 export default function GameFeature() {
   return (
     <div className="p-4">
-      <StunningDartboard />
+      <GameHUD />
     </div>
   )
 }

--- a/src/components/hud/GameHUD.js
+++ b/src/components/hud/GameHUD.js
@@ -1,0 +1,60 @@
+'use client'
+import { useState } from 'react'
+import StunningDartboard from '../dartboard/StunningDartboard'
+
+function Panel({ player, collapsed, side }) {
+  return (
+    <div className={`hud-side ${side} ${collapsed ? 'collapsed' : ''}`}>
+      <div className="player-name">{player.name}</div>
+      <div className="player-score">{player.score}</div>
+      <div className="marks-row">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className={`cricket-dot ${player.marks > i ? `hit-${player.marks}` : ''}`}
+          ></span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function GameHUD() {
+  const [players] = useState([
+    { id: 1, name: 'Player 1', score: 0, marks: 0 },
+    { id: 2, name: 'Player 2', score: 0, marks: 0 },
+  ])
+  const [currentPlayer, setCurrentPlayer] = useState(1)
+  const [dartCount, setDartCount] = useState(1)
+  const [round, setRound] = useState(1)
+
+  return (
+    <div className="game-hud">
+      <div className="hud-top-bar">
+        <button aria-label="Game Mode">🎮</button>
+        <button aria-label="Players">👥</button>
+        <button aria-label="Score">🏆</button>
+        <button aria-label="Settings">⚙️</button>
+      </div>
+      <Panel
+        player={players[0]}
+        collapsed={currentPlayer !== 1}
+        side="left"
+      />
+      <div className="hud-board">
+        <StunningDartboard />
+      </div>
+      <Panel
+        player={players[1]}
+        collapsed={currentPlayer !== 2}
+        side="right"
+      />
+      <div className="hud-bottom">
+        <button aria-label="Undo">Undo</button>
+        <div>Darts: {dartCount}</div>
+        <div>Round: {round}</div>
+        <button aria-label="Next">Next</button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/hud/__tests__/GameHUD.test.js
+++ b/src/components/hud/__tests__/GameHUD.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import GameHUD from '../GameHUD'
+
+describe('GameHUD', () => {
+  it('renders dartboard and hud sections', () => {
+    render(<GameHUD />)
+    expect(
+      screen.getByRole('heading', { name: /precision dartboard/i })
+    ).toBeInTheDocument()
+    expect(document.querySelector('.hud-top-bar')).toBeInTheDocument()
+    expect(document.querySelectorAll('.hud-side').length).toBe(2)
+    expect(document.querySelector('.hud-bottom')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add new `GameHUD` component composing dartboard with HUD panels
- style HUD elements and cricket dots in `globals.css`
- replace use of `StunningDartboard` with `GameHUD`
- test HUD renders all expected sections

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cdd46c4b4832e9274229ef9c18d4d