### PR TITLE
Add neon highlight classes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,3 +79,4 @@ body {
 .cricket-dot.hit-1 { background: #facc15; }
 .cricket-dot.hit-2,
 .cricket-dot.hit-3 { background: #22c55e; }
+.active-segment { filter: drop-shadow(0 0 8px #fcd34d); }

--- a/src/components/dartboard/DartboardSVG.js
+++ b/src/components/dartboard/DartboardSVG.js
@@ -7,6 +7,7 @@ const DartboardSVG = ({
   generateNumbers,
   handleDartThrow,
   BullseyeGlowWrapper,
+  highlightedSegments = [],
 }) => (
   <div className="dartboard-component">
     <div className="dartboard-glow"></div>
@@ -114,13 +115,13 @@ const DartboardSVG = ({
           </filter>
         </defs>
         <g transform="translate(50, 50)">
-          {generateSegments()}
+          {generateSegments(highlightedSegments)}
           <BullseyeGlowWrapper>
             <circle
               cx={center}
               cy={center}
               r={radii.bullOuter}
-              className="segment color-g"
+              className={`segment color-g ${highlightedSegments.includes('single-bull') ? 'active-segment' : ''}`}
               data-score="single-bull"
               onClick={() => handleDartThrow('single-bull')}
             />
@@ -130,7 +131,7 @@ const DartboardSVG = ({
               cx={center}
               cy={center}
               r={radii.bullInner}
-              className="segment color-r"
+              className={`segment color-r ${highlightedSegments.includes('double-bull') ? 'active-segment' : ''}`}
               data-score="double-bull"
               onClick={() => handleDartThrow('double-bull')}
             />

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -1377,6 +1377,7 @@ const StunningDartboard = () => {
 
   const handleMouseOver = (e, score) => {
     if (score) {
+      e.target.classList.add('active-segment')
       const formattedScore = formatScore(score)
       setHoverScore(formattedScore)
       setIsScoreActive(true)
@@ -1404,6 +1405,7 @@ const StunningDartboard = () => {
 
   const handleMouseOut = (e) => {
     setHoverScore('')
+    e.target.classList.remove('active-segment')
     e.target.classList.remove('glow-bust-warning')
   }
   const createSegmentPath = (
@@ -1426,7 +1428,7 @@ const StunningDartboard = () => {
     return `M ${x1} ${y1} L ${x2} ${y2} A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${x3} ${y3} L ${x4} ${y4} A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${x1} ${y1} Z`
   }
 
-  const generateSegments = () => {
+  const generateSegments = (highlightList = highlightedSegments) => {
     const segments = []
     const isX01Game = ['301', '501', '701'].includes(gameMode)
 
@@ -1470,8 +1472,9 @@ const StunningDartboard = () => {
         const segmentId = seg.name.replace('-outer', '').replace('-inner', '')
         let combinedClasses = `segment ${seg.color}`
 
-        const highlightIndex = highlightedSegments.indexOf(segmentId)
+        const highlightIndex = highlightList.indexOf(segmentId)
         if (highlightIndex !== -1) {
+          combinedClasses += ' active-segment'
           if (isX01Game) {
             combinedClasses += ` x01-checkout-target glow-suggested-${highlightIndex + 1}`
           } else if (gameMode === 'cricket') {
@@ -1709,8 +1712,11 @@ const StunningDartboard = () => {
     }
 
     const highlightIndex = highlightedSegments.indexOf(segmentId)
-    if (highlightIndex !== -1 && isX01Game) {
-      combinedClasses += ` x01-checkout-target glow-suggested-${highlightIndex + 1}`
+    if (highlightIndex !== -1) {
+      combinedClasses += ' active-segment'
+      if (isX01Game) {
+        combinedClasses += ` x01-checkout-target glow-suggested-${highlightIndex + 1}`
+      }
     }
 
     return React.cloneElement(children, {
@@ -2178,6 +2184,7 @@ const StunningDartboard = () => {
               generateNumbers={generateNumbers}
               handleDartThrow={handleDartThrow}
               BullseyeGlowWrapper={BullseyeGlowWrapper}
+              highlightedSegments={highlightedSegments}
             />
           }
         />


### PR DESCRIPTION
## Summary
- implement active segment drop-shadow styles
- forward highlighted segments to `DartboardSVG`
- add `active-segment` class management on hover

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce134b414832e93b65d9deeb2a037