### PR TITLE
Add HUD overlays

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,3 +111,64 @@ body {
 .active-segment {
   filter: drop-shadow(0 0 8px #fcd34d);
 }
+
+.game-type-pill {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  opacity: 0;
+}
+.game-type-pill.show {
+  animation: fadeSlide 1.2s forwards;
+}
+
+.score-overlay {
+  position: absolute;
+  top: 10%;
+  right: 15%;
+  font-size: 1.5rem;
+  color: #facc15;
+  pointer-events: none;
+  animation: fadeInOut 1s forwards;
+}
+
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes fadeSlide {
+  0% {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+}

--- a/src/components/dartboard/StunningDartboard.js
+++ b/src/components/dartboard/StunningDartboard.js
@@ -5,7 +5,7 @@ import ScoreboardUI from './ScoreboardUI'
 import DartboardSVG from './DartboardSVG'
 
 // Main component for the Stunning Dartboard application
-const StunningDartboard = () => {
+const StunningDartboard = ({ onScore }) => {
   // State for hover effects on the dartboard
   const [hoverScore, setHoverScore] = useState('')
   const [isScoreActive, setIsScoreActive] = useState(false)
@@ -643,6 +643,8 @@ const StunningDartboard = () => {
       number = parseInt(parts[1])
       points = number * multiplier
     }
+
+    if (onScore) onScore(points)
 
     const updatedTurnScores = [...turnScores, points]
     setTurnScores(updatedTurnScores)

--- a/src/components/hud/GameHUD.js
+++ b/src/components/hud/GameHUD.js
@@ -1,6 +1,13 @@
 'use client'
 import { useState } from 'react'
 import StunningDartboard from '../dartboard/StunningDartboard'
+import ScoreOverlay from './ScoreOverlay'
+
+function GameTypePill({ gameType, visible }) {
+  return (
+    <div className={`game-type-pill ${visible ? 'show' : ''}`}>{gameType}</div>
+  )
+}
 
 function Panel({ player, collapsed, side }) {
   return (
@@ -27,11 +34,30 @@ export default function GameHUD() {
   const [currentPlayer, setCurrentPlayer] = useState(1)
   const [dartCount, setDartCount] = useState(1)
   const [round, setRound] = useState(1)
+  const [gameType, setGameType] = useState('501')
+  const [showGameType, setShowGameType] = useState(false)
+  const [overlay, setOverlay] = useState(null)
+
+  const gameTypes = ['501', 'Cricket']
+
+  const cycleGameType = () => {
+    const idx = gameTypes.indexOf(gameType)
+    const next = gameTypes[(idx + 1) % gameTypes.length]
+    setGameType(next)
+    setShowGameType(true)
+    setTimeout(() => setShowGameType(false), 1200)
+  }
+
+  const handleScore = (points) => {
+    const id = Date.now()
+    setOverlay({ value: points, id })
+    setTimeout(() => setOverlay(null), 1000)
+  }
 
   return (
     <div className="game-hud">
       <div className="hud-top-bar">
-        <button aria-label="Game Mode">🎮</button>
+        <button aria-label="Game Mode" onClick={cycleGameType}>🎮</button>
         <button aria-label="Players">👥</button>
         <button aria-label="Score">🏆</button>
         <button aria-label="Settings">⚙️</button>
@@ -42,7 +68,9 @@ export default function GameHUD() {
         side="left"
       />
       <div className="hud-board">
-        <StunningDartboard />
+        <StunningDartboard onScore={handleScore} />
+        <GameTypePill gameType={gameType} visible={showGameType} />
+        {overlay && <ScoreOverlay score={overlay.value} id={overlay.id} />}
       </div>
       <Panel
         player={players[1]}

--- a/src/components/hud/ScoreOverlay.js
+++ b/src/components/hud/ScoreOverlay.js
@@ -1,0 +1,9 @@
+'use client'
+export default function ScoreOverlay({ score, id }) {
+  if (score == null) return null
+  return (
+    <div key={id} className="score-overlay">
+      {score}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show the current game type through a floating pill
- animate score text near the board whenever a dart hits
- wire `StunningDartboard` to report scores
- style overlays and animations

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ce7e4fc78832eb5d0e34bb1abdb81